### PR TITLE
fix: add missing return statements after error responses in controllers

### DIFF
--- a/src/controllers/editProject.ts
+++ b/src/controllers/editProject.ts
@@ -7,6 +7,7 @@ export const handleEditProject = async (req: Request, res: Response) => {
   try {
     if (!commitMessage) {
       res.status(300).json({ message: "Commit message is required" });
+      return;
     }
     await updateProjectDataFile(repoName, projectData, commitMessage);
     res.status(200).json({ message: "Project updated successfully" });

--- a/src/controllers/forkProject.ts
+++ b/src/controllers/forkProject.ts
@@ -6,6 +6,7 @@ export const handleForkProject = async (req: Request, res: Response) => {
 
     if (!repositoryName) {
         res.status(400).json({ error: "Missing required fields" });
+        return;
     }
 
     try {

--- a/src/controllers/pullRequest.ts
+++ b/src/controllers/pullRequest.ts
@@ -6,6 +6,7 @@ export const handleCreatePR = async (req: Request, res: Response) => {
 
     if (!forkRepo || !updatedProjectData) {
         res.status(400).json({ error: 'forkRepo and updatedProjectData are required.' });
+        return;
     }
 
     try {


### PR DESCRIPTION
Fixes #6 Several controllers were missing return statements after sending error responses, causing code to continue executing even after a response was sent. This could lead to duplicate responses, server-side errors, and unpredictable API behavior.

**Changes**
Added return statements after early error responses in three controller files:

- [editProject.ts](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) return after missing [commitMessage](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) check
- [forkProject.ts](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) return after missing [repositoryName](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) check
- [pullRequest.ts](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) return after missing [forkRepo](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[updatedProjectData](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) check

**Testing**
- Project builds successfully (npm run build)
- All 147 existing tests pass (npm test)
- The one pre-existing test suite failure in hash.test.ts is unrelated (undefined variable)