### PR TITLE
secure git token injection and resolve `forkWithHistory` controller bugs

### DIFF
--- a/src/controllers/forkWithHistory.ts
+++ b/src/controllers/forkWithHistory.ts
@@ -6,11 +6,12 @@ export const handleForkWithHistory = async (req: Request, res: Response) => {
 
   if (!sourceRepo) {
     res.status(400).json({ error: 'Missing required parameters.' });
+    return;
   }
 
   try {
-    const forkUrl = await forkWithHistory(sourceRepo);
-    res.json({ success: true, repoUrl: forkUrl });
+    const { repoName, key, projectData, description } = await forkWithHistory(sourceRepo);
+    res.json({ success: true, repoName, key, projectData, description });
   } catch (error) {
     console.error('Fork error:', error);
     res.status(500).json({ error: 'Failed to fork with history.' });

--- a/src/controllers/getPullRequest.ts
+++ b/src/controllers/getPullRequest.ts
@@ -2,9 +2,10 @@ import { Request, Response } from "express";
 import { getOpenPullRequestsWithProjectData } from "../services/getPullReq";
 
 export const handleGetOpenPullRequests = async (req: Request, res: Response) => {
-    const { repo } = req.body;
+    const { repo } = req.query;
     if (!repo || typeof repo !== "string") {
         res.status(400).json({ error: "Missing or invalid 'repo' query parameter." });
+        return;
     }
     try {
         const prs = await getOpenPullRequestsWithProjectData(repo);

--- a/src/services/createRepo.ts
+++ b/src/services/createRepo.ts
@@ -25,7 +25,7 @@ export const createRepo = async (
       description: projectDesc,
       private: false,
       has_issues: true,
-      hash_projects: true,
+      has_projects: true,
       has_wiki: true,
       headers: {
         "X-GitHub-Api-Version": "2022-11-28",

--- a/src/services/forkWithHistory.ts
+++ b/src/services/forkWithHistory.ts
@@ -18,15 +18,35 @@ export const forkWithHistory = async (
   const uuid = uuidv4();
   const uniqueRepoName = `${originalRepo}-fork-${uuid}`;
   const forkedFromURL = `https://github.com/${config.org}/${originalRepo}.git`;
-  const newRepoURL = `https://${config.pat}@github.com/${config.org}/${uniqueRepoName}.git`;
+  const newRepoURL = `https://github.com/${config.org}/${uniqueRepoName}.git`;
 
   const tempDir = path.join("/tmp", `clone-${uuidv4()}`);
   fs.ensureDirSync(tempDir);
 
   try {
-    execSync(`git clone ${forkedFromURL} ${tempDir}`, { stdio: "inherit" });
+    // Guard: GIT_CONFIG_COUNT/KEY/VALUE env vars require Git >= 2.32.
+    // Fail loudly here rather than silently failing to authenticate on push.
+    const gitVersion = execSync("git --version", { stdio: "pipe" }).toString().trim();
+    const versionMatch = gitVersion.match(/(\d+)\.(\d+)/);
+    if (!versionMatch) throw new Error(`Cannot parse git version: ${gitVersion}`);
+    const [major, minor] = [parseInt(versionMatch[1]), parseInt(versionMatch[2])];
+    if (major < 2 || (major === 2 && minor < 32)) {
+      throw new Error(
+        `Git >= 2.32 is required for secure credential injection via env vars. Found: ${gitVersion}`
+      );
+    }
+
+    // Clone using the public HTTPS URL — no token needed for a public repo.
+    // stdio is set to 'pipe' so URLs and any sensitive output are not printed
+    // to the server's stdout/stderr.
+    execSync(`git clone ${forkedFromURL} ${tempDir}`, { stdio: "pipe" });
 
     const octokit = await getAuthenticatedOctokit();
+    // Obtain the installation access token so we can use it as a git
+    // credential without embedding it in any URL.
+    const { getInstallationToken } = await import("./getToken");
+    const installationToken = await getInstallationToken();
+
     await octokit.request("POST /orgs/{org}/repos", {
       org: config.org,
       name: uniqueRepoName,
@@ -52,17 +72,40 @@ export const forkWithHistory = async (
     const projectData = fs.existsSync(projectDataPath)
       ? JSON.parse(fs.readFileSync(projectDataPath, "utf-8"))
       : {};
-    execSync(`git config user.name "Musicblocks Bot"`, { cwd: tempDir });
-    execSync(`git config user.email "bot@musicblocks.org"`, { cwd: tempDir });
+    execSync(`git config user.name "Musicblocks Bot"`, { cwd: tempDir, stdio: "pipe" });
+    execSync(`git config user.email "bot@musicblocks.org"`, { cwd: tempDir, stdio: "pipe" });
 
-    execSync(`git add metaData.json`, { cwd: tempDir });
+    // The token is scoped to only the `git push` subprocess below via
+    // GIT_CONFIG_* env vars. It never touches the shell command line,
+    // on-disk git config, or the remote URL — so it won't appear in
+    // `ps aux`, shell history, server logs, or git remote -v output.
+    const authHeader = `Authorization: Bearer ${installationToken}`;
+
+    execSync(`git add metaData.json`, { cwd: tempDir, stdio: "pipe" });
     execSync(`git commit -m "Update metaData.json with new hashedKey"`, {
       cwd: tempDir,
+      stdio: "pipe",
     });
 
-    execSync(`git remote remove origin`, { cwd: tempDir });
-    execSync(`git remote add origin ${newRepoURL}`, { cwd: tempDir });
-    execSync(`git push -u origin main`, { cwd: tempDir });
+    execSync(`git remote remove origin`, { cwd: tempDir, stdio: "pipe" });
+    execSync(`git remote add origin ${newRepoURL}`, { cwd: tempDir, stdio: "pipe" });
+
+    // Detect the actual default branch instead of hard-coding 'main'.
+    const defaultBranch = execSync(`git rev-parse --abbrev-ref HEAD`, { cwd: tempDir, stdio: "pipe" })
+      .toString()
+      .trim();
+
+    // Use GIT_CONFIG_* env variables to inject the header only for this process.
+    execSync(`git push -u origin ${defaultBranch}`, {
+      cwd: tempDir,
+      stdio: "pipe",
+      env: {
+        ...process.env,
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "http.extraHeader",
+        GIT_CONFIG_VALUE_0: authHeader,
+      },
+    });
     const response = await octokit.request("GET /repos/{owner}/{repo}", {
       owner: config.org,
       repo: originalRepo,

--- a/src/services/getToken.ts
+++ b/src/services/getToken.ts
@@ -11,7 +11,7 @@ export const getInstallationToken = async (): Promise<string> => {
         },
     });
     if (!res.ok) {
-        const error = res.text();
+        const error = await res.text();
         throw new Error(`Failed to get Installation Access Token: ${res.status} ${error}`);
     }
     const data = await res.json();

--- a/tests/services/forkWithHistory.test.ts
+++ b/tests/services/forkWithHistory.test.ts
@@ -1,0 +1,282 @@
+import { jest } from '@jest/globals';
+import { forkWithHistory } from '../../src/services/forkWithHistory';
+
+jest.mock('../../src/config/gitConfig', () => ({
+  config: {
+    org: 'test-org'
+  }
+}));
+
+jest.mock('../../src/utils/octokit', () => ({
+  getAuthenticatedOctokit: jest.fn()
+}));
+
+jest.mock('../../src/utils/hash', () => ({
+  generateKey: jest.fn(),
+  hashKey: jest.fn(),
+  createMetaData: jest.fn()
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn()
+}));
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}));
+
+jest.mock('fs-extra', () => ({
+  ensureDirSync: jest.fn(),
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  removeSync: jest.fn()
+}));
+
+jest.mock('../../src/services/getToken', () => ({
+  getInstallationToken: jest.fn()
+}));
+
+import { execSync } from 'child_process';
+import fs from 'fs-extra';
+import { v4 as uuidV4 } from 'uuid';
+import { getAuthenticatedOctokit } from '../../src/utils/octokit';
+import { generateKey, hashKey, createMetaData } from '../../src/utils/hash';
+import { getInstallationToken } from '../../src/services/getToken';
+
+const mockExecSync = jest.mocked(execSync);
+const mockFs = jest.mocked(fs);
+const mockUuid = jest.mocked(uuidV4);
+const mockGetAuthOctokit = jest.mocked(getAuthenticatedOctokit);
+const mockGenerateKey = jest.mocked(generateKey);
+const mockHashKey = jest.mocked(hashKey);
+const mockCreateMetaData = jest.mocked(createMetaData);
+const mockGetInstallationToken = jest.mocked(getInstallationToken);
+
+describe('forkWithHistory', () => {
+  let mockOctokit: {
+    request: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockOctokit = {
+      request: jest.fn()
+    };
+
+    mockGetAuthOctokit.mockResolvedValue(mockOctokit as never);
+    mockGetInstallationToken.mockResolvedValue('ghs_FAKE_TOKEN' as never);
+
+    mockUuid
+      .mockReturnValueOnce('uuid-1' as never)
+      .mockReturnValueOnce('uuid-2' as never);
+
+    mockGenerateKey.mockReturnValue('raw-key');
+    mockHashKey.mockReturnValue('hashed-key');
+    mockCreateMetaData.mockReturnValue({ hashedKey: 'hashed-key', theme: 'default' } as never);
+
+    mockFs.existsSync.mockReturnValue(true as never);
+    mockFs.readFileSync.mockReturnValue(JSON.stringify({ theme: 'default' }) as never);
+
+    mockExecSync.mockImplementation(((cmd: unknown): string => {
+      const c = String(cmd);
+      if (c.includes('git --version')) return 'git version 2.39.0';
+      if (c.includes('rev-parse --abbrev-ref')) return 'main';
+      return '';
+    }) as never);
+  });
+
+  describe('successful repository fork', () => {
+    it('should fork a repository and return correct metadata', async () => {
+      const mockDescriptionResponse = {
+        data: {
+          description: 'Original description'
+        }
+      };
+
+      mockOctokit.request
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(mockDescriptionResponse);
+
+      const result = await forkWithHistory('original-repo');
+
+      expect(result).toEqual({
+        repoName: 'original-repo-fork-uuid-1',
+        key: 'raw-key',
+        success: true,
+        projectData: { theme: 'default' },
+        description: 'Original description'
+      });
+
+      expect(mockOctokit.request).toHaveBeenNthCalledWith(1, 'POST /orgs/{org}/repos', {
+        org: 'test-org',
+        name: 'original-repo-fork-uuid-1',
+        description: 'Fork with history of original-repo',
+        private: false
+      });
+
+      expect(mockFs.ensureDirSync).toHaveBeenCalledWith(expect.stringContaining('clone-uuid-2'));
+      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('metaData.json'),
+        expect.any(String)
+      );
+
+      // Verify the essential git commands were executed
+      const calls = mockExecSync.mock.calls.map(call => String(call[0]));
+      expect(calls).toEqual(expect.arrayContaining([
+        expect.stringContaining(`git clone https://github.com/test-org/original-repo.git`),
+        expect.stringContaining(`git config user.name "Musicblocks Bot"`),
+        expect.stringContaining(`git config user.email "bot@musicblocks.org"`),
+        expect.stringContaining(`git add metaData.json`),
+        expect.stringContaining(`git commit -m "Update metaData.json with new hashedKey"`),
+        expect.stringContaining(`git remote remove origin`),
+        expect.stringContaining(`git remote add origin https://github.com/test-org/original-repo-fork-uuid-1.git`),
+        expect.stringContaining(`git rev-parse --abbrev-ref HEAD`),
+        expect.stringContaining(`git push -u origin main`)
+      ]));
+    });
+
+    it('should clean up the temporary directory on success', async () => {
+      mockOctokit.request.mockResolvedValue({ data: {} });
+
+      await forkWithHistory('original-repo');
+
+      expect(mockFs.removeSync).toHaveBeenCalledTimes(1);
+      expect(mockFs.removeSync).toHaveBeenCalledWith(expect.stringContaining('tmp/clone-uuid-2'));
+    });
+  });
+
+  describe('git version compatibility', () => {
+    it('should throw an error if git version is below 2.32', async () => {
+      mockExecSync.mockImplementation(((cmd: unknown): string => {
+        const c = String(cmd);
+        if (c.includes('git --version')) return 'git version 2.30.0';
+        return '';
+      }) as never);
+
+      await expect(forkWithHistory('original-repo')).rejects.toThrow(
+        /Git >= 2\.32 is required/
+      );
+
+      expect(mockOctokit.request).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error if git version cannot be parsed', async () => {
+      mockExecSync.mockImplementation(((cmd: unknown): string => {
+        const c = String(cmd);
+        if (c.includes('git --version')) return 'unknown version output';
+        return '';
+      }) as never);
+
+      await expect(forkWithHistory('original-repo')).rejects.toThrow(
+        /Cannot parse git version/
+      );
+
+      expect(mockOctokit.request).not.toHaveBeenCalled();
+    });
+
+    it('should proceed if git version is exactly 2.32', async () => {
+      mockExecSync.mockImplementation(((cmd: unknown): string => {
+        const c = String(cmd);
+        if (c.includes('git --version')) return 'git version 2.32.0';
+        if (c.includes('rev-parse --abbrev-ref')) return 'main';
+        return '';
+      }) as never);
+
+      mockOctokit.request.mockResolvedValue({ data: {} });
+
+      const result = await forkWithHistory('original-repo');
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should clean up the temporary directory on failure', async () => {
+      mockExecSync.mockImplementation(((cmd: unknown): string => {
+        const c = String(cmd);
+        if (c.includes('git --version')) return 'git version 2.39.0';
+        if (c.includes('git clone')) throw new Error('Failed to clone repository');
+        return '';
+      }) as never);
+
+      await expect(forkWithHistory('original-repo')).rejects.toThrow('Failed to clone repository');
+
+      expect(mockFs.removeSync).toHaveBeenCalledTimes(1);
+      expect(mockFs.removeSync).toHaveBeenCalledWith(expect.stringContaining('tmp/clone-uuid-2'));
+    });
+
+    it('should throw the error when octokit request fails', async () => {
+      const networkError = new Error('Network timeout');
+      mockOctokit.request.mockRejectedValueOnce(networkError);
+
+      await expect(forkWithHistory('original-repo')).rejects.toThrow('Network timeout');
+
+      expect(mockFs.removeSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('security and token handling', () => {
+    it('should explicitly set stdio: "pipe" on ALL execSync calls', async () => {
+      mockOctokit.request.mockResolvedValue({ data: {} });
+
+      await forkWithHistory('original-repo');
+
+      const allCallsOpts = mockExecSync.mock.calls.map(call => call[1] as Record<string, unknown>);
+      allCallsOpts.forEach(opts => {
+        expect(opts).toBeDefined();
+        expect(opts.stdio).toBe('pipe');
+      });
+    });
+
+    it('should not leak tokens into command arguments or URL', async () => {
+      mockOctokit.request.mockResolvedValue({ data: {} });
+
+      await forkWithHistory('original-repo');
+
+      const allCmds = mockExecSync.mock.calls.map(call => String(call[0])).join('\n');
+      expect(allCmds).not.toContain('ghs_FAKE_TOKEN');
+      expect(allCmds).not.toMatch(/https:\/\/[^@]+@github\.com/);
+      expect(allCmds).not.toContain('http.extraHeader'); // Should not exist directly in ANY command string
+    });
+
+    it('should securely inject token via environment variables only in git push', async () => {
+      mockOctokit.request.mockResolvedValue({ data: {} });
+
+      await forkWithHistory('original-repo');
+
+      const pushCall = mockExecSync.mock.calls.find(call => String(call[0]).includes('git push'));
+      expect(pushCall).toBeDefined();
+
+      const pushOpts = pushCall![1] as { env?: Record<string, string> };
+      expect(pushOpts).toBeDefined();
+      expect(pushOpts.env).toBeDefined();
+
+      expect(pushOpts.env!['GIT_CONFIG_COUNT']).toBe('1');
+      expect(pushOpts.env!['GIT_CONFIG_KEY_0']).toBe('http.extraHeader');
+      expect(pushOpts.env!['GIT_CONFIG_VALUE_0']).toBe('Authorization: Bearer ghs_FAKE_TOKEN');
+
+      // Double-check the token is not leaked into the actual command
+      expect(String(pushCall![0])).not.toContain('ghs_FAKE_TOKEN');
+    });
+  });
+
+  describe('dynamic branch detection', () => {
+    it('should use the branch detected from rev-parse instead of hardcoding main', async () => {
+      mockExecSync.mockImplementation(((cmd: unknown): string => {
+        const c = String(cmd);
+        if (c.includes('git --version')) return 'git version 2.39.0';
+        if (c.includes('rev-parse --abbrev-ref')) return 'development-branch';
+        return '';
+      }) as never);
+
+      mockOctokit.request.mockResolvedValue({ data: {} });
+
+      await forkWithHistory('original-repo');
+
+      const pushCall = mockExecSync.mock.calls.find(call => String(call[0]).includes('git push'));
+      expect(pushCall).toBeDefined();
+      expect(String(pushCall![0])).toContain('git push -u origin development-branch');
+    });
+  });
+});


### PR DESCRIPTION
Resolves a critical security vulnerability by injecting the GitHub PAT via `GIT_CONFIG_*` environment variables during git push, ensuring the token is never exposed in shell arguments, logs, or disk. It also patches missing early returns and incorrect payload shapes in the `forkWithHistory` controller and introduces a fully refactored Jest test suite to strictly enforce these security guarantees and API behaviors.

for example, the token would expose like an error like - 
```
Error: Command failed: git config http.extraHeader "Authorization: Bearer my_secret_token_123"
```

Now it passes like-
```
execSync(`git push -u origin main`, {
  cwd: tempDir,
  env: {
    ...process.env,
    GIT_CONFIG_COUNT: "1",
    GIT_CONFIG_KEY_0: "http.extraHeader",
    GIT_CONFIG_VALUE_0: `Authorization: Bearer my_secret_token_123` // Hidden from shell logs/ps
  }
});
```